### PR TITLE
Update outdated/wrong CTPoint calculation

### DIFF
--- a/src/states/stChassisISESBP.java
+++ b/src/states/stChassisISESBP.java
@@ -157,7 +157,7 @@ public class stChassisISESBP implements ifChassis, ifState {
     }
 
     private int GetIndex( int Tonnage ) {
-        return (Tonnage - 100) / 5 - 1;
+        return Tonnage / 5 - 2;
     }
 
     public MechModifier GetMechModifier() {


### PR DESCRIPTION
Fixes https://github.com/WEKarnesky/solarisskunkwerks/issues/10 by updating an incorrect CTPoint calculation that triggers an exception when loading mechs from .ssw files