### PR TITLE
Apply streak heat BV modifier to SRMs only

### DIFF
--- a/src/components/RangedWeapon.java
+++ b/src/components/RangedWeapon.java
@@ -543,7 +543,7 @@ public class RangedWeapon extends abPlaceable implements ifWeapon {
         if( Rotary ) { retval *= 6; }
         if( Ultra ) { retval *= 2; }
         if( OneShot ) { retval *= 0.25; }
-        if( Streak ) { retval *= 0.5; }
+        if( Streak && this.ChatName.contains( "Streak SRM" ) ) { retval *= 0.5; }
         if( retval < 0 ) { retval = 0; }
         return retval;
     }


### PR DESCRIPTION
Fix https://github.com/WEKarnesky/solarisskunkwerks/issues/13 by applying the streak BV modifier to only SRMs instead of all streak weapons.